### PR TITLE
PN-2555 aggiunto limit size array InternalIds

### DIFF
--- a/docs/openapi/pn-datavault-api-v1.yaml
+++ b/docs/openapi/pn-datavault-api-v1.yaml
@@ -92,6 +92,8 @@ paths:
             type: array
             items:
               $ref: '#/components/schemas/InternalId'
+            minItems: 1
+            maxItems: 100
       responses:
         '200':
           description: OK

--- a/src/test/java/it/pagopa/pn/datavault/LocalStackTestConfig.java
+++ b/src/test/java/it/pagopa/pn/datavault/LocalStackTestConfig.java
@@ -22,7 +22,7 @@ import static org.testcontainers.containers.localstack.LocalStackContainer.Servi
 public class LocalStackTestConfig {
 
     static LocalStackContainer localStack =
-            new LocalStackContainer(DockerImageName.parse(getImageName()).asCompatibleSubstituteFor("localstack/localstack"))
+            new LocalStackContainer(DockerImageName.parse(getImageName()))
                     .withServices(DYNAMODB)
                     .withClasspathResourceMapping("testcontainers/init.sh",
                             "/docker-entrypoint-initaws.d/make-storages.sh", BindMode.READ_ONLY)
@@ -44,6 +44,6 @@ public class LocalStackTestConfig {
     }
 
     private static String getImageName() {
-        return System.getProperty("localstack_image_name", "public.ecr.aws/localstack/localstack:1.0.4");
+        return "localstack/localstack:1.0.4";
     }
 }

--- a/src/test/java/it/pagopa/pn/datavault/rest/RecipientsRestControllerV1Test.java
+++ b/src/test/java/it/pagopa/pn/datavault/rest/RecipientsRestControllerV1Test.java
@@ -15,6 +15,8 @@ import reactor.core.publisher.Mono;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 @WebFluxTest(controllers = {RecipientsRestControllerV1.class})
 class RecipientsRestControllerV1Test {
@@ -67,5 +69,29 @@ class RecipientsRestControllerV1Test {
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus().isOk().expectBodyList(BaseRecipientDto.class);
+    }
+
+    @Test
+    void getRecipientDenominationByInternalIdButFailedValidationSize() {
+
+        String url = "/datavault-private/v1/recipients/internal?internalId={internalId}"
+                .replace("{internalId}", "123e4567-e89b-12d3-a456-426655440000");
+
+        StringBuilder urlBuilder = new StringBuilder(url);
+
+        String otherInternalIds = "&internalId=123e4567-e89b-12d3-a456-426655440000";
+
+        urlBuilder.append(otherInternalIds.repeat(100));
+
+        String finalUrl = urlBuilder.toString();
+
+        assertThat(finalUrl.split("internalId")).hasSizeGreaterThan(100);
+
+
+        webTestClient.get()
+                .uri(finalUrl)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isBadRequest();
     }
 }


### PR DESCRIPTION
Limite a 100 elementi dell'array degli internalIds per l'API getRecipientDenominationByInternalId.